### PR TITLE
fixed content_block.twig sometimes receiving wrong element in loop

### DIFF
--- a/templates/content_block.twig
+++ b/templates/content_block.twig
@@ -1,6 +1,6 @@
 {% set open = false %}
 
-{% for value in res.contents %}
+{% for value in res.contents.byclass.content_block %}
 
     {% if open != value.attributes.layout.value %}
 


### PR DESCRIPTION
the for loop on content_block.twig changed to only loop 'byclass' content_bock, to prevent the loop from being distracted by other potential wrong elements